### PR TITLE
fix: Update API health check to use products table instead of pg_tables

### DIFF
--- a/lib/supabase/health-check.ts
+++ b/lib/supabase/health-check.ts
@@ -4,11 +4,10 @@ export async function checkDatabaseHealth() {
   try {
     const supabase = await createClient()
 
-    // Simple health check - test connection
+    // Simple health check - test connection using our products table
     const { data, error } = await supabase
-      .from('pg_tables')
-      .select('tablename')
-      .eq('schemaname', 'public')
+      .from('products')
+      .select('id')
       .limit(1)
 
     if (error) {
@@ -23,7 +22,7 @@ export async function checkDatabaseHealth() {
       status: 'healthy',
       message: 'Database connection successful',
       timestamp: new Date().toISOString(),
-      tablesFound: data?.length || 0
+      recordsFound: data?.length || 0
     }
   } catch (error) {
     return {


### PR DESCRIPTION
## Summary

- Fix API health check endpoint that was failing with pg_tables permissions error
- Replace pg_tables query with products table for better compatibility with Supabase anon role
- Update response field from tablesFound to recordsFound for clarity
- Testing confirmed: Database connection successful, API response time 284ms

## Test plan

- [x] Database connection test using custom script ✅
- [x] API health check endpoint (`/api/health`) returns HTTP 200 ✅  
- [x] Response time under 300ms ✅
- [x] Environment variables validation ✅
- [x] Build validation: 100% PASS ✅
- [x] Linter validation: 100% PASS ✅

## Testing Results

```bash
# Database connection test
✅ Database connection successful!
📊 Products table: 1 records accessible
📊 Members table: 1 records accessible  
📊 Price tiers table: 1 records accessible

# API health check test
curl -s http://localhost:3000/api/health
Status: healthy ✅
HTTP Status: 200 ✅
Response Time: 0.284145s ✅
```

🤖 Generated with Claude Code